### PR TITLE
Silence GCC -Wcast-qual warning

### DIFF
--- a/include/boost/atomic/detail/gcc-atomic.hpp
+++ b/include/boost/atomic/detail/gcc-atomic.hpp
@@ -61,7 +61,7 @@ public:
 
     void clear(memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
     {
-        __atomic_clear((bool*)&v_, atomics::detail::convert_memory_order_to_gcc(order));
+        __atomic_clear(const_cast<bool*>(&v_), atomics::detail::convert_memory_order_to_gcc(order));
     }
 };
 


### PR DESCRIPTION
Use C++ casts instead of C-style casts in order to silence warning about casting away qualifiers.

warning: cast from type 'volatile bool_' to type 'bool_' casts away qualifiers [-Wcast-qual]
