### PR TITLE
Add explicit dependency on Boost.Test

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,6 +14,7 @@ project boost/atomic/test
       <threading>multi
       <library>/boost/thread//boost_thread
       <library>/boost/atomic//boost_atomic
+      <use>/boost/test//boost_unit_test_framework
       <target-os>windows:<define>BOOST_USE_WINDOWS_H
       <target-os>windows:<define>_WIN32_WINNT=0x0500
       <toolset>gcc,<target-os>windows:<linkflags>"-lkernel32"


### PR DESCRIPTION
Atomic uses the "included" header-only version of Boost.Test. So explicitly add Boost.Test as a dependency via the `<use>` mechanism. This solves the test failures after latest Boost.Test refactorings.