### PR TITLE
Make initializing constructor of atomic<> implicit.

### DIFF
--- a/include/boost/atomic/detail/atomic_template.hpp
+++ b/include/boost/atomic/detail/atomic_template.hpp
@@ -29,9 +29,9 @@
 #include <boost/atomic/detail/type_traits/is_integral.hpp>
 #include <boost/atomic/detail/type_traits/is_function.hpp>
 #include <boost/atomic/detail/type_traits/is_floating_point.hpp>
+#include <boost/atomic/detail/type_traits/is_trivially_default_constructible.hpp>
 #include <boost/atomic/detail/type_traits/conditional.hpp>
 #include <boost/atomic/detail/type_traits/integral_constant.hpp>
-#include <boost/atomic/detail/type_traits/is_trivially_default_constructible.hpp>
 #if !defined(BOOST_ATOMIC_NO_FLOATING_POINT)
 #include <boost/atomic/detail/bitwise_fp_cast.hpp>
 #include <boost/atomic/detail/fp_operations_fwd.hpp>
@@ -318,7 +318,7 @@ protected:
 
 public:
     BOOST_DEFAULTED_FUNCTION(base_atomic() BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_DECL, BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_IMPL {})
-    BOOST_CONSTEXPR explicit base_atomic(value_arg_type v) BOOST_NOEXCEPT : m_storage(v) {}
+    BOOST_FORCEINLINE BOOST_CONSTEXPR explicit base_atomic(value_arg_type v) BOOST_NOEXCEPT : m_storage(v) {}
 
     // Standard methods
     BOOST_FORCEINLINE void store(value_arg_type v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
@@ -642,7 +642,7 @@ protected:
 
 public:
     BOOST_DEFAULTED_FUNCTION(base_atomic() BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_DECL, BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_IMPL {})
-    BOOST_CONSTEXPR explicit base_atomic(value_arg_type v) BOOST_NOEXCEPT : m_storage(v) {}
+    BOOST_FORCEINLINE BOOST_CONSTEXPR explicit base_atomic(value_arg_type v) BOOST_NOEXCEPT : m_storage(v) {}
 
     // Standard methods
     BOOST_FORCEINLINE void store(value_arg_type v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
@@ -1133,12 +1133,13 @@ public:
 
 public:
     BOOST_DEFAULTED_FUNCTION(atomic() BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_DECL, BOOST_ATOMIC_DETAIL_DEF_NOEXCEPT_IMPL {})
+    BOOST_FORCEINLINE BOOST_CONSTEXPR atomic(value_arg_type v) BOOST_NOEXCEPT : base_type(v) {}
 
-    // NOTE: The constructor is made explicit because gcc 4.7 complains that
-    //       operator=(value_arg_type) is considered ambiguous with operator=(atomic const&)
-    //       in assignment expressions, even though conversion to atomic<> is less preferred
-    //       than conversion to value_arg_type.
-    BOOST_FORCEINLINE explicit BOOST_CONSTEXPR atomic(value_arg_type v) BOOST_NOEXCEPT : base_type(v) {}
+    BOOST_FORCEINLINE value_type operator= (value_arg_type v) BOOST_NOEXCEPT
+    {
+        this->store(v);
+        return v;
+    }
 
     BOOST_FORCEINLINE value_type operator= (value_arg_type v) volatile BOOST_NOEXCEPT
     {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -28,4 +28,5 @@ test-suite atomic
       [ compile-fail cf_arith_void_ptr.cpp ]
       [ compile-fail cf_arith_func_ptr.cpp ]
       [ compile-fail cf_arith_mem_ptr.cpp ]
+      [ compile c_implicit_ctor.cpp ]
     ;

--- a/test/c_implicit_ctor.cpp
+++ b/test/c_implicit_ctor.cpp
@@ -1,0 +1,34 @@
+//  Copyright (c) 2018 Andrey Semashev
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+// The test verifies that atomic<T> has an implicit conversion constructor from T.
+// This can only be tested in C++17 because it has mandated copy elision. Previous C++ versions
+// also require atomic<> to have a copy or move constructor, which it does not.
+#if __cplusplus >= 201703L
+
+#include <boost/atomic.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/config.hpp>
+#include <type_traits>
+
+int main(int, char *[])
+{
+    static_assert(std::is_convertible< int, boost::atomic< int > >::value, "boost::atomic<T> does not have an implicit constructor from T");
+
+    boost::atomic< short > a = 10;
+    (void)a;
+
+    return 0;
+}
+
+#else // __cplusplus >= 201703L
+
+int main(int, char *[])
+{
+    return 0;
+}
+
+#endif // __cplusplus >= 201703L


### PR DESCRIPTION
This is an attempt to make `boost::atomic<>` interface closer to the standard. It
makes a difference in C++17 as it mandates copy elision, which makes this code
possible:

```
boost::atomic<int> a = 10;
```

It also makes `is_convertible<T, boost::atomic<T>>` return `true`, which has
implications on the standard library components, such as std::pair.

This removes the workaround for gcc 4.7, which complains that
`operator=(value_arg_type)` is considered ambiguous with `operator=(atomic const&)`
in assignment expressions, even though conversion to `atomic<>` is less preferred
than conversion to `value_arg_type`. We try to work around the problem from the
`operator=` side.

Added a new compile test to check that the initializing constructor is implicit.