### PR TITLE
Fix invalid const atomic builtin accesses

### DIFF
--- a/include/boost/atomic/detail/ops_gcc_x86_dcas.hpp
+++ b/include/boost/atomic/detail/ops_gcc_x86_dcas.hpp
@@ -119,7 +119,7 @@ struct gcc_dcas_x86
         }
     }
 
-    static BOOST_FORCEINLINE storage_type load(storage_type const volatile& storage, memory_order) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE storage_type load(storage_type volatile& storage, memory_order) BOOST_NOEXCEPT
     {
         storage_type value;
 
@@ -404,7 +404,7 @@ struct gcc_dcas_x86_64
         );
     }
 
-    static BOOST_FORCEINLINE storage_type load(storage_type const volatile& storage, memory_order) BOOST_NOEXCEPT
+    static BOOST_FORCEINLINE storage_type load(storage_type volatile& storage, memory_order) BOOST_NOEXCEPT
     {
         // Note that despite const qualification cmpxchg16b below may issue a store to the storage. The storage value
         // will not change, but this prevents the storage to reside in read-only memory.


### PR DESCRIPTION
Clang fixed a signature issue with builtin atomic functions wrongly
allowing const-qualified arguments. This change removes the invalid
const qualifiers from those calls.

Fixes:
boost/atomic/detail/ops_gcc_x86_dcas.hpp:408:16: error: address argument
to atomic builtin cannot be const-qualified ('const volatile
boost::atomics::detail::gcc_dcas_x86_64::storage_type *' (aka 'const
volatile unsigned __int128 *') invalid)
        return __sync_val_compare_and_swap(&storage, value, value);

Signed-off-by: Khem Raj <raj.khem@gmail.com>