### PR TITLE
Add minimal cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,20 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
+    # cmake self-test
+    - os: linux
+      env: TEST_CMAKE=TRUE #Only for easier identification in travis web gui
+      install:
+        - git clone --depth 1 https://github.com/boostorg/assert.git ../assert
+        - git clone --depth 1 https://github.com/boostorg/config.git ../config
+        - git clone --depth 1 https://github.com/boostorg/static_assert.git ../static_assert
+        - git clone --depth 1 https://github.com/boostorg/type_traits.git ../type_traits
+
+      script:
+        - mkdir __build__ && cd __build__
+        - cmake ../test/test_cmake
+        - cmake --build .
+
 # gcc, Linux
     - os: linux
       env: TOOLSET=gcc COMPILER=g++ CXXSTD64=03,11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.5)
+project(BoostAtomic LANGUAGES CXX)
+
+add_library(boost_atomic src/lockpool.cpp)
+add_library(Boost::atomic ALIAS boost_atomic)
+
+target_include_directories(boost_atomic PUBLIC include)
+
+target_link_libraries(boost_atomic
+    PUBLIC
+        Boost::assert
+        Boost::config
+        Boost::type_traits
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
 cmake_minimum_required(VERSION 3.5)
 project(BoostAtomic LANGUAGES CXX)
 

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.Atomic.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostBindCMakeSelfTest )
+
+add_subdirectory( ../../../assert ${CMAKE_CURRENT_BINARY_DIR}/libs/assert )
+add_subdirectory( ../../../config ${CMAKE_CURRENT_BINARY_DIR}/libs/config )
+add_subdirectory( ../../../static_assert ${CMAKE_CURRENT_BINARY_DIR}/libs/static_assert )
+add_subdirectory( ../../../type_traits ${CMAKE_CURRENT_BINARY_DIR}/libs/type_traits )
+
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/boost_atomic )
+
+add_executable( boost_atomic_cmake_self_test main.cpp )
+target_link_libraries( boost_atomic_cmake_self_test Boost::atomic )
+

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,20 @@
+//  Copyright (c) 2018 Mike Dev
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/atomic.hpp>
+
+struct Dummy {
+    int a, b, c, d;
+};
+
+int main() {
+    Dummy d = { 1,2,3,4 };
+    boost::atomic<Dummy> ad;
+
+    // this operation requires functions from
+    // the compiled part of Boost.Atomic
+    ad = d;
+}


### PR DESCRIPTION
Allows the integration of a local Boost.Atomic copy into a cmake project via `add_subdirectory( libs/atomic )`