### PR TITLE
[CMake] Add static_assert dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(boost_atomic
   PUBLIC
     Boost::assert
     Boost::config
+    Boost::static_assert
     Boost::type_traits
 )
 


### PR DESCRIPTION
Required in detail/atomic_ref_template.hpp and detail/atomic_template.hpp.