### PR TITLE
Remove boost_install call from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,3 @@ if(BUILD_SHARED_LIBS)
 else()
   target_compile_definitions(boost_atomic PUBLIC BOOST_ATOMIC_STATIC_LINK)
 endif()
-
-if(BOOST_SUPERPROJECT_VERSION)
-
-  include(BoostInstall)
-  boost_install(TARGETS boost_atomic HEADER_DIRECTORY include/)
-
-endif()


### PR DESCRIPTION
Predef has been added as a dependency and it doesn't have install support, which causes errors such as
```
CMake Error: install(EXPORT "boost_atomic-targets" ...) includes target "boost_atomic" which requires target "boost_predef" that is not in the export set.
```
because CMake is picky about these things.

The superproject can add install support automatically nowadays (but only on CMake 3.13 or later), so an explicit `boost_install` call isn't necessary and the easiest way forward is just to not do it. I'll be gradually removing these `boost_install` calls from all other libraries as well.