### PR TITLE
extra_ops.hpp: adapt to AIX assembler

### DIFF
--- a/include/boost/atomic/detail/core_arch_ops_gcc_ppc.hpp
+++ b/include/boost/atomic/detail/core_arch_ops_gcc_ppc.hpp
@@ -29,6 +29,14 @@
 #pragma once
 #endif
 
+#if !defined(_AIX)
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL(label) label ":\n\t"
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP(insn, label, offset) insn " " label "\n\t"
+#else
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL(label)
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP(insn, label, offset) insn " $" offset "\n\t"
+#endif
+
 namespace boost {
 namespace atomics {
 namespace detail {
@@ -113,8 +121,8 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
             (
                 "lwz %0, %1\n\t"
                 "cmpw %0, %0\n\t"
-                "bne- 1f\n\t"
-                "1:\n\t"
+                BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+4")
+                BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
                 "isync\n\t"
                 : "=&r" (v)
                 : "m" (storage)
@@ -139,10 +147,10 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y1\n\t"
             "stwcx. %2,%y1\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-8")
             : "=&b" (original), "+Z" (storage)
             : "b" (v)
             : "cr0"
@@ -161,11 +169,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
             "li %1, 0\n\t"
             "lwarx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stwcx. %4,%y2\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+8")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -185,13 +193,14 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         __asm__ __volatile__
         (
             "li %1, 0\n\t"
-            "0: lwarx %0,%y2\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("0")
+            "lwarx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stwcx. %4,%y2\n\t"
-            "bne- 0b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "0b", "-16")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -209,11 +218,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -228,11 +237,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -247,11 +256,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -266,11 +275,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -285,11 +294,11 @@ struct core_arch_operations< 4u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -344,8 +353,8 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
             (
                 "lbz %0, %1\n\t"
                 "cmpw %0, %0\n\t"
-                "bne- 1f\n\t"
-                "1:\n\t"
+                BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+4")
+                BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
                 "isync\n\t"
                 : "=&r" (v)
                 : "m" (storage)
@@ -370,10 +379,10 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y1\n\t"
             "stbcx. %2,%y1\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-8")
             : "=&b" (original), "+Z" (storage)
             : "b" (v)
             : "cr0"
@@ -392,11 +401,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
             "li %1, 0\n\t"
             "lbarx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stbcx. %4,%y2\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+8")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -416,13 +425,14 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         __asm__ __volatile__
         (
             "li %1, 0\n\t"
-            "0: lbarx %0,%y2\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("0")
+            "lbarx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stbcx. %4,%y2\n\t"
-            "bne- 0b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "0b", "-16")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -440,11 +450,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -459,11 +469,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -478,11 +488,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -497,11 +507,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -516,11 +526,11 @@ struct core_arch_operations< 1u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -555,12 +565,12 @@ struct core_arch_operations< 1u, false, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "rlwinm %1, %1, 0, 0xff\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -575,12 +585,12 @@ struct core_arch_operations< 1u, false, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "rlwinm %1, %1, 0, 0xff\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -603,12 +613,12 @@ struct core_arch_operations< 1u, true, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "extsb %1, %1\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -623,12 +633,12 @@ struct core_arch_operations< 1u, true, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "extsb %1, %1\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -675,8 +685,8 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
             (
                 "lhz %0, %1\n\t"
                 "cmpw %0, %0\n\t"
-                "bne- 1f\n\t"
-                "1:\n\t"
+                BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+4")
+                BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
                 "isync\n\t"
                 : "=&r" (v)
                 : "m" (storage)
@@ -701,10 +711,10 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y1\n\t"
             "sthcx. %2,%y1\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-8")
             : "=&b" (original), "+Z" (storage)
             : "b" (v)
             : "cr0"
@@ -723,11 +733,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
             "li %1, 0\n\t"
             "lharx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "sthcx. %4,%y2\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+8")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -747,13 +757,14 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         __asm__ __volatile__
         (
             "li %1, 0\n\t"
-            "0: lharx %0,%y2\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("0")
+            "lharx %0,%y2\n\t"
             "cmpw %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "sthcx. %4,%y2\n\t"
-            "bne- 0b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "0b", "-16")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -771,11 +782,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -790,11 +801,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -809,11 +820,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -828,11 +839,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -847,11 +858,11 @@ struct core_arch_operations< 2u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -886,12 +897,12 @@ struct core_arch_operations< 2u, false, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "rlwinm %1, %1, 0, 0xffff\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -906,12 +917,12 @@ struct core_arch_operations< 2u, false, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "rlwinm %1, %1, 0, 0xffff\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -934,12 +945,12 @@ struct core_arch_operations< 2u, true, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "extsh %1, %1\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -954,12 +965,12 @@ struct core_arch_operations< 2u, true, Interprocess > :
         base_type::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "extsh %1, %1\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-16")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -1006,8 +1017,8 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
             (
                 "ld %0, %1\n\t"
                 "cmpd %0, %0\n\t"
-                "bne- 1f\n\t"
-                "1:\n\t"
+                BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+4")
+                BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
                 "isync\n\t"
                 : "=&b" (v)
                 : "m" (storage)
@@ -1032,10 +1043,10 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y1\n\t"
             "stdcx. %2,%y1\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-8")
             : "=&b" (original), "+Z" (storage)
             : "b" (v)
             : "cr0"
@@ -1054,11 +1065,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
             "li %1, 0\n\t"
             "ldarx %0,%y2\n\t"
             "cmpd %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stdcx. %4,%y2\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+8")
             "li %1, 1\n\t"
-            "1:"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -1078,13 +1089,14 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         __asm__ __volatile__
         (
             "li %1, 0\n\t"
-            "0: ldarx %0,%y2\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("0")
+            "ldarx %0,%y2\n\t"
             "cmpd %0, %3\n\t"
-            "bne- 1f\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1f", "+16")
             "stdcx. %4,%y2\n\t"
-            "bne- 0b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "0b", "-16")
             "li %1, 1\n\t"
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             : "=&b" (expected), "=&b" (success), "+Z" (storage)
             : "b" (expected), "b" (desired)
             : "cr0"
@@ -1102,11 +1114,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -1121,11 +1133,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -1140,11 +1152,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -1159,11 +1171,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -1178,11 +1190,11 @@ struct core_arch_operations< 8u, Signed, Interprocess > :
         fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC

--- a/include/boost/atomic/detail/extra_ops_gcc_ppc.hpp
+++ b/include/boost/atomic/detail/extra_ops_gcc_ppc.hpp
@@ -28,6 +28,14 @@
 #pragma once
 #endif
 
+#if !defined(_AIX)
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL(label) label ":\n\t"
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP(insn, label, offset) insn " " label "\n\t"
+#else
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL(label)
+#define BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP(insn, label, offset) insn " $" offset "\n\t"
+#endif
+
 namespace boost {
 namespace atomics {
 namespace detail {
@@ -103,11 +111,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -122,11 +130,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -141,11 +149,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -160,11 +168,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -179,11 +187,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -198,11 +206,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -217,11 +225,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -236,11 +244,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -255,11 +263,11 @@ struct extra_operations_gcc_ppc< Base, 1u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lbarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stbcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -292,11 +300,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -311,11 +319,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -330,11 +338,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -349,11 +357,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -368,11 +376,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -387,11 +395,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -406,11 +414,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -425,11 +433,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -444,11 +452,11 @@ struct extra_operations_gcc_ppc< Base, 2u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lharx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "sthcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -473,11 +481,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -492,11 +500,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -511,11 +519,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -530,11 +538,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -549,11 +557,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -568,11 +576,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -587,11 +595,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -606,11 +614,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -625,11 +633,11 @@ struct extra_operations_gcc_ppc< Base, 4u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "lwarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stwcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -660,11 +668,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -679,11 +687,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "neg %1,%0\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -698,11 +706,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "add %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -717,11 +725,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "sub %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -736,11 +744,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "and %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -755,11 +763,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "or %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -774,11 +782,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         core_arch_operations_gcc_ppc_base::fence_before(order);
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "xor %1,%0,%3\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             : "b" (v)
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -793,11 +801,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC
@@ -812,11 +820,11 @@ struct extra_operations_gcc_ppc< Base, 8u, Signed > :
         storage_type original, result;
         __asm__ __volatile__
         (
-            "1:\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_LABEL("1")
             "ldarx %0,%y2\n\t"
             "nor %1,%0,%0\n\t"
             "stdcx. %1,%y2\n\t"
-            "bne- 1b\n\t"
+            BOOST_ATOMIC_DETAIL_PPC_ASM_JUMP("bne-", "1b", "-12")
             : "=&b" (original), "=&b" (result), "+Z" (storage)
             :
             : BOOST_ATOMIC_DETAIL_ASM_CLOBBER_CC


### PR DESCRIPTION
AIX assembler doesn't allow "bne- 1b" to jump to the previous label "1".
It must be replaced by "bne- $N", N being the memory offset between
the current instruction and the targeted label.