### PR TITLE
Fix relative includes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,15 @@ environment:
       CXXSTD: 03,11,03-gnu,11-gnu
       ADDPATH: C:\cygwin64\bin
       B2_ARGS: instruction-set=core2
+      # Cygwin 3.0.7
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 64
+      CXXSTD: 03,11,03-gnu,11-gnu
+      ADDPATH: C:\cygwin64\bin
+      B2_ARGS: instruction-set=core2
+      # Cygwin 3.1.7
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
     - TOOLSET: gcc
       ADDRESS_MODEL: 64
       CXXSTD: 03,11,14,03-gnu,11-gnu,14-gnu

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -74,6 +74,7 @@ for local src in $(BOOST_ATOMIC_SOURCES_SSE2)
             <link>shared:<define>BOOST_ATOMIC_DYN_LINK=1
             <link>static:<define>BOOST_ATOMIC_STATIC_LINK=1
             <define>BOOST_ATOMIC_SOURCE
+            <include>../src
         ;
 
     explicit $(src) ;
@@ -89,6 +90,7 @@ for local src in $(BOOST_ATOMIC_SOURCES_SSE41)
             <link>shared:<define>BOOST_ATOMIC_DYN_LINK=1
             <link>static:<define>BOOST_ATOMIC_STATIC_LINK=1
             <define>BOOST_ATOMIC_SOURCE
+            <include>../src
         ;
 
     explicit $(src) ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -16,6 +16,7 @@ project boost/atomic/test
       <library>/boost/chrono//boost_chrono
       <library>/boost/thread//boost_thread
       <library>/boost/atomic//boost_atomic
+      <include>.
       <target-os>windows:<define>BOOST_USE_WINDOWS_H
       <toolset>gcc,<target-os>windows:<linkflags>"-lkernel32"
       # Variadic macros and empty macro arguments are used by Boost.Preprocessor even in C++03 mode, which makes gcc and clang complain


### PR DESCRIPTION
This adds a test job on Appveyor using a more recent Cygwin to reproduce #56: The use of relative includes requires explicitly adding the current source files path on some systems.
This is then done for the few cases where relative includes are used:
- src/find_address_sse2.cpp
- src/find_address_sse41.cpp
- various test files

Note that the src folder is already added to the include-path however this doesn't affect the arch-specific files which have separate build rules and hence need that requirement explicitly there.

I'm not fully sure about the distinction between the B2 `project` and `lib` rules but moving the `<include>../src` from the `lib` to the `project` requirements is also a solution to this issue and avoids the repetition of that at 3 places. But I'm not sure if that has any unwanted side effects. Especially as `<define>BOOST_ATOMIC_SOURCE` as well as the DYN_LINK/STATIC_LINK defines are also repeated between the `project` rule and the arch-specific `obj` rules for which I don't understand the reason.