### PR TITLE
Improve endianness checks portability on ARM, AArch32 and AArch64

### DIFF
--- a/doc/changelog.qbk
+++ b/doc/changelog.qbk
@@ -1,11 +1,15 @@
 [/
- / Copyright (c) 2021 Andrey Semashev
+ / Copyright (c) 2021-2022 Andrey Semashev
  /
  / Distributed under the Boost Software License, Version 1.0. (See accompanying
  / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  /]
 
 [section:changelog Changelog]
+
+[heading Boost 1.80]
+
+* Improved portability of endianness checks on ARM, AArch32 and AArch64 targets. ([github_issue 59])
 
 [heading Boost 1.79]
 

--- a/include/boost/atomic/detail/caps_arch_gcc_aarch32.hpp
+++ b/include/boost/atomic/detail/caps_arch_gcc_aarch32.hpp
@@ -3,7 +3,7 @@
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
  *
- * Copyright (c) 2020 Andrey Semashev
+ * Copyright (c) 2020, 2022 Andrey Semashev
  */
 /*!
  * \file   atomic/detail/caps_arch_gcc_aarch32.hpp
@@ -31,7 +31,14 @@
     (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__))
 #define BOOST_ATOMIC_DETAIL_AARCH32_BIG_ENDIAN
 #else
+#include <boost/predef/other/endian.h>
+#if BOOST_ENDIAN_LITTLE_BYTE
+#define BOOST_ATOMIC_DETAIL_AARCH32_LITTLE_ENDIAN
+#elif BOOST_ENDIAN_BIG_BYTE
+#define BOOST_ATOMIC_DETAIL_AARCH32_BIG_ENDIAN
+#else
 #error "Boost.Atomic: Failed to determine AArch32 endianness, the target platform is not supported. Please, report to the developers (patches are welcome)."
+#endif
 #endif
 
 #define BOOST_ATOMIC_INT8_LOCK_FREE 2

--- a/include/boost/atomic/detail/caps_arch_gcc_aarch64.hpp
+++ b/include/boost/atomic/detail/caps_arch_gcc_aarch64.hpp
@@ -3,7 +3,7 @@
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
  *
- * Copyright (c) 2020 Andrey Semashev
+ * Copyright (c) 2020, 2022 Andrey Semashev
  */
 /*!
  * \file   atomic/detail/caps_arch_gcc_aarch64.hpp
@@ -31,7 +31,14 @@
     (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__))
 #define BOOST_ATOMIC_DETAIL_AARCH64_BIG_ENDIAN
 #else
+#include <boost/predef/other/endian.h>
+#if BOOST_ENDIAN_LITTLE_BYTE
+#define BOOST_ATOMIC_DETAIL_AARCH64_LITTLE_ENDIAN
+#elif BOOST_ENDIAN_BIG_BYTE
+#define BOOST_ATOMIC_DETAIL_AARCH64_BIG_ENDIAN
+#else
 #error "Boost.Atomic: Failed to determine AArch64 endianness, the target platform is not supported. Please, report to the developers (patches are welcome)."
+#endif
 #endif
 
 #if defined(__ARM_FEATURE_ATOMICS)

--- a/include/boost/atomic/detail/caps_arch_gcc_arm.hpp
+++ b/include/boost/atomic/detail/caps_arch_gcc_arm.hpp
@@ -7,7 +7,7 @@
  * Copyright (c) 2009 Phil Endecott
  * Copyright (c) 2013 Tim Blechmann
  * ARM Code by Phil Endecott, based on other architectures.
- * Copyright (c) 2014, 2020 Andrey Semashev
+ * Copyright (c) 2014, 2020, 2022 Andrey Semashev
  */
 /*!
  * \file   atomic/detail/caps_arch_gcc_arm.hpp
@@ -36,7 +36,14 @@
     (defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__))
 #define BOOST_ATOMIC_DETAIL_ARM_BIG_ENDIAN
 #else
+#include <boost/predef/other/endian.h>
+#if BOOST_ENDIAN_LITTLE_BYTE
+#define BOOST_ATOMIC_DETAIL_ARM_LITTLE_ENDIAN
+#elif BOOST_ENDIAN_BIG_BYTE
+#define BOOST_ATOMIC_DETAIL_ARM_BIG_ENDIAN
+#else
 #error "Boost.Atomic: Failed to determine ARM endianness, the target platform is not supported. Please, report to the developers (patches are welcome)."
+#endif
 #endif
 
 #if defined(__GNUC__) && defined(__arm__) && (BOOST_ATOMIC_DETAIL_ARM_ARCH >= 6)


### PR DESCRIPTION
When gcc predefined macros are not defined, use Boost.Predef (which also checks macros defined in the system endian.h header) to detect endianness. This may help with gcc impostor compilers that do not define built-in endianness macros.

Closes https://github.com/boostorg/atomic/issues/59.
