### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -6,11 +6,9 @@
 require-b2 5.2 ;
 
 constant boost_dependencies :
-    /boost/align//boost_align
     /boost/assert//boost_assert
     /boost/config//boost_config
     /boost/predef//boost_predef
-    /boost/preprocessor//boost_preprocessor
     /boost/type_traits//boost_type_traits
     /boost/winapi//boost_winapi ;
 

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ project /boost/atomic
         <library>/boost/config//boost_config
         <library>/boost/predef//boost_predef
         <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/static_assert//boost_static_assert
         <library>/boost/type_traits//boost_type_traits
         <library>/boost/winapi//boost_winapi
     ;

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,28 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/atomic
+    : common-requirements
+        <include>include
+        <source>/boost/align//boost_align
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/predef//boost_predef
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/winapi//boost_winapi
+    ;
+
+explicit
+    [ alias boost_atomic : build//boost_atomic ]
+    [ alias all : boost_atomic test ]
+    ;
+
+call-if : boost-library atomic
+    : install boost_atomic
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,16 +5,18 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/align//boost_align
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/predef//boost_predef
+    /boost/preprocessor//boost_preprocessor
+    /boost/type_traits//boost_type_traits
+    /boost/winapi//boost_winapi ;
+
 project /boost/atomic
     : common-requirements
         <include>include
-        <library>/boost/align//boost_align
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/predef//boost_predef
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/winapi//boost_winapi
     ;
 
 explicit
@@ -25,3 +27,4 @@ explicit
 call-if : boost-library atomic
     : install boost_atomic
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -8,14 +8,14 @@ import project ;
 project /boost/atomic
     : common-requirements
         <include>include
-        <source>/boost/align//boost_align
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/predef//boost_predef
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/winapi//boost_winapi
+        <library>/boost/align//boost_align
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/predef//boost_predef
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/winapi//boost_winapi
     ;
 
 explicit

--- a/build.jam
+++ b/build.jam
@@ -6,16 +6,13 @@
 require-b2 5.2 ;
 
 constant boost_dependencies :
-    /boost/assert//boost_assert
-    /boost/config//boost_config
-    /boost/predef//boost_predef
-    /boost/type_traits//boost_type_traits
-    /boost/winapi//boost_winapi ;
+    <library>/boost/assert//boost_assert
+    <library>/boost/config//boost_config
+    <library>/boost/predef//boost_predef
+    <library>/boost/type_traits//boost_type_traits
+    <target-os>windows:<library>/boost/winapi//boost_winapi ;
 
-project /boost/atomic
-    : common-requirements
-        <include>include
-    ;
+project /boost/atomic ;
 
 explicit
     [ alias boost_atomic : build//boost_atomic ]
@@ -25,4 +22,3 @@ explicit
 call-if : boost-library atomic
     : install boost_atomic
     ;
-

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/atomic
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/atomic

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -43,9 +43,15 @@ local cxx_requirements = [ requires
       cxx11_static_assert
     ] ;
 
+constant boost_dependencies_private :
+    /boost/align//boost_align
+    /boost/preprocessor//boost_preprocessor
+    ;
+
 project
     : common-requirements <library>$(boost_dependencies)
     : requirements
+      <library>$(boost_dependencies_private)
       <include>../src
       <threading>multi
       <link>shared:<define>BOOST_ATOMIC_DYN_LINK=1

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -7,6 +7,8 @@
 #  (See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt)
 
+import-search /boost/config/checks ;
+
 import common ;
 import config : requires ;
 import path ;
@@ -14,12 +16,6 @@ import project ;
 import feature ;
 import configure ;
 import atomic-arch-config ;
-
-local here = [ modules.binding $(__name__) ] ;
-
-project.push-current [ project.current ] ;
-project.load [ path.join [ path.make $(here:D) ] ../../config/checks/architecture ] ;
-project.pop-current ;
 
 lib synchronization ;
 explicit synchronization ;
@@ -47,7 +43,7 @@ local cxx_requirements = [ requires
       cxx11_static_assert
     ] ;
 
-project boost/atomic
+project
     : requirements
       <include>../src
       <threading>multi
@@ -150,5 +146,3 @@ lib boost_atomic
       <conditional>@check-synchronization-lib
       $(cxx_requirements)
    ;
-
-boost-install boost_atomic ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -44,6 +44,7 @@ local cxx_requirements = [ requires
     ] ;
 
 project
+    : common-requirements <library>$(boost_dependencies)
     : requirements
       <include>../src
       <threading>multi

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -55,6 +55,7 @@ project
     : usage-requirements
       <link>shared:<define>BOOST_ATOMIC_DYN_LINK=1
       <link>static:<define>BOOST_ATOMIC_STATIC_LINK=1
+      <define>BOOST_ATOMIC_NO_LIB=1
     : source-location ../src
     ;
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -43,15 +43,13 @@ local cxx_requirements = [ requires
       cxx11_static_assert
     ] ;
 
-constant boost_dependencies_private :
-    /boost/align//boost_align
-    /boost/preprocessor//boost_preprocessor
-    ;
-
 project
-    : common-requirements <library>$(boost_dependencies)
+    : common-requirements
+      <include>../include
+      $(boost_dependencies)
     : requirements
-      <library>$(boost_dependencies_private)
+      <library>/boost/align//boost_align
+      <library>/boost/preprocessor//boost_preprocessor
       <include>../src
       <threading>multi
       <link>shared:<define>BOOST_ATOMIC_DYN_LINK=1

--- a/build/atomic-arch-config.jam
+++ b/build/atomic-arch-config.jam
@@ -19,23 +19,23 @@ rule deduce-architecture ( properties * )
     }
     else
     {
-        if [ configure.builds /boost/architecture//x86 : $(properties) : "x86" ]
+        if [ configure.builds /boost/config/checks/architecture//x86 : $(properties) : "x86" ]
         {
             return x86 ;
         }
-        else if [ configure.builds /boost/architecture//arm : $(properties) : "arm" ]
+        else if [ configure.builds /boost/config/checks/architecture//arm : $(properties) : "arm" ]
         {
             return arm ;
         }
-        else if [ configure.builds /boost/architecture//mips1 : $(properties) : "mips1" ]
+        else if [ configure.builds /boost/config/checks/architecture//mips1 : $(properties) : "mips1" ]
         {
             return mips1 ;
         }
-        else if [ configure.builds /boost/architecture//power : $(properties) : "power" ]
+        else if [ configure.builds /boost/config/checks/architecture//power : $(properties) : "power" ]
         {
             return power ;
         }
-        else if [ configure.builds /boost/architecture//sparc : $(properties) : "sparc" ]
+        else if [ configure.builds /boost/config/checks/architecture//sparc : $(properties) : "sparc" ]
         {
             return sparc ;
         }
@@ -51,11 +51,11 @@ rule deduce-address-model ( properties * )
     }
     else
     {
-        if [ configure.builds /boost/architecture//32 : $(properties) : "32-bit" ]
+        if [ configure.builds /boost/config/checks/architecture//32 : $(properties) : "32-bit" ]
         {
             return 32 ;
         }
-        else if [ configure.builds /boost/architecture//64 : $(properties) : "64-bit" ]
+        else if [ configure.builds /boost/config/checks/architecture//64 : $(properties) : "64-bit" ]
         {
             return 64 ;
         }


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.